### PR TITLE
Update debian dir for new packaging standard

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: vdr-plugin-recsearch
 Section: video
 Priority: extra
 Maintainer: Lars Hanisch <dvb@flensrocker.de>
-Build-Depends: debhelper (>= 8), vdr-dev (>= 2.0.0), pkg-config
+Build-Depends: debhelper (>= 8), vdr-dev (>= 2.2.0-1), pkg-config
 Standards-Version: 3.9.1
 Homepage: https://github.com/flensrocker/vdr-plugin-recsearch
 

--- a/debian/rules
+++ b/debian/rules
@@ -2,18 +2,18 @@
 
 #DH_VERBOSE=1
 
+PLG_PACKAGE = $(filter-out %-dbg, $(shell dh_listpackages))
+DBG_PACKAGE = $(filter %-dbg, $(shell dh_listpackages))
+
 .PHONY: override_dh_gencontrol override_dh_strip override_dh_auto_install
 
-override_dh_gencontrol:
-	sh /usr/share/vdr-dev/dependencies.sh
-	dh_gencontrol
 
 override_dh_strip:
-	dh_strip --dbg-package=vdr-plugin-recsearch-dbg
+	dh_strip --dbg-package=$(DBG_PACKAGE)
 
 override_dh_auto_install:
-	dh_auto_install --destdir=debian/vdr-plugin-recsearch
+	dh_auto_install --destdir=debian/$(PLG_PACKAGE)
 
 %:
-	dh $@
+	dh $@ --with vdrplugin
 


### PR DESCRIPTION
Please apply as needed, if your new vdr package is copied to unstable-vdr for trusty